### PR TITLE
fix when using multiple versions of html-webpack-plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -578,7 +578,7 @@ HtmlWebpackTagsPlugin.prototype.apply = function (compiler) {
     const HtmlWebpackPlugin = require(htmlPluginName);
     if (HtmlWebpackPlugin.getHooks) {
       const hooks = HtmlWebpackPlugin.getHooks(compilation);
-      const htmlPlugins = compilation.options.plugins.filter(plugin => plugin instanceof HtmlWebpackPlugin);
+      const htmlPlugins = compilation.options.plugins.filter(plugin => plugin.constructor.name == HtmlWebpackPlugin.name);
       if (htmlPlugins.length === 0) {
         const message = "Error running html-webpack-tags-plugin, are you sure you have html-webpack-plugin before it in your webpack config's plugins?";
         throw new Error(message);


### PR DESCRIPTION
I have experienced issue when use with vue-cli because of multiple versions 'html-webpack-plugin'. Issue fixed by checking with its constructor name instead of class instance.