### PR TITLE
Added missing webpack peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "url": "https://github.com/jharris4/html-webpack-tags-plugin/issues"
   },
   "homepage": "https://github.com/jharris4/html-webpack-tags-plugin",
+  "peerDependencies": {
+    "webpack": "^5.0.0"
+  },
   "devDependencies": {
     "cheerio": "^1.0.0-rc.5",
     "copy-webpack-plugin": "^7.0.0",


### PR DESCRIPTION
The `html-webpack-tags-plugin` hasn't specified `webpack` as a peer dependency. This lead to problems, because strict package managers can't resolve and install the correct dependency. This PR adds this missing dependency and fixes this problem.