### PR TITLE
fix finding instances of HtmlWebpackPlugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -581,7 +581,7 @@ HtmlWebpackTagsPlugin.prototype.apply = function (compiler) {
     const HtmlWebpackPlugin = require(htmlPluginName);
     if (HtmlWebpackPlugin.getHooks) {
       const hooks = HtmlWebpackPlugin.getHooks(compilation);
-      const htmlPlugins = compilation.options.plugins.filter(plugin => plugin instanceof HtmlWebpackPlugin);
+      const htmlPlugins = compilation.options.plugins.filter(plugin => plugin && plugin.constructor.name === "HtmlWebpackPlugin");
       if (htmlPlugins.length === 0) {
         const message = "Error running html-webpack-tags-plugin, are you sure you have html-webpack-plugin before it in your webpack config's plugins?";
         throw new Error(message);


### PR DESCRIPTION
Using `instanceof HtmlWebpackPlugin` doesn't work in projects with multiple versions of `html-webpack-plugin` and causes the following error message:
```
Error running html-webpack-tags-plugin, are you sure you have html-webpack-plugin before it in your webpack config's plugins?
```

Checking the constructor name instead should be more robust and seems to be common practice, too.